### PR TITLE
Panic prints the message then errors out

### DIFF
--- a/src/lang.rs
+++ b/src/lang.rs
@@ -7,6 +7,17 @@ extern fn eh_personality() {}
 extern fn eh_unwind_resume() {}
 
 #[lang = "panic_fmt"]
-extern fn panic_impl(_: core::fmt::Arguments, _: &'static str, _: u32) -> ! {
-	loop{}
+extern fn panic_impl(args: core::fmt::Arguments, file : &'static str, line : u32) -> ! {
+    use ::core::fmt::Write;
+    use ::std::io::KernelDebugWriter;
+    let mut writer = KernelDebugWriter {};
+
+    print!("Panicked at '");
+    // If this fails to write, just leave the quotes empty.
+    let _ = writer.write_fmt(args);
+    println!("', {}:{}", file, line);
+    // Force a null pointer read to crash.
+    unsafe{ let _ = *(core::ptr::null::<i32>()); }
+    // If that doesn't work, loop forever.
+    loop{}
 }


### PR DESCRIPTION
`panic_impl` intentionally dereferences a null pointer to cause the kernel
to detect a BUG and include the stacktrace.

This is much better than the previous behaviour of looping forever.